### PR TITLE
Fix bug in release creation process

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Tag 
         uses: K-Phoen/semver-release-action@v1.3.1
         with:
-          release_branch: master
+          release_branch: main
           release_strategy: tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The process was set to trigger on the `master` branch, but the main
branch in this repository is called `main`.