### PR TITLE
Add misspell check via reviewdog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -41,3 +41,13 @@ jobs:
           path: "."
           pattern: "*.sh"
           exclude: "./.git/*"
+
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check


### PR DESCRIPTION
NB if we add golangci-lint linting for go then we will probably
include misspell checking there too.  We also want misspell to check
markdown files too though, so we'll still need this separate check as
well.

There will be no harm in having any go file spelling errors being
reported twice.