### PR TITLE
Rename GitHub release action

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -1,5 +1,5 @@
 ---
-name: Tag
+name: Release
 
 on:  # yamllint disable-line rule:truthy
   pull_request:


### PR DESCRIPTION
The new name is more descriptive.