### PR TITLE
Check commit messages for correctness

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,0 +1,18 @@
+---
+name: 'Check commit message style'
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+
+jobs:
+  check-commit-message-style:
+    name: Check commit message style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2.0.0


### PR DESCRIPTION
Using a third party GitHub Action[1], which checks commit messages
based on the guidelines set out by Chris Beams[2]

[1] https://github.com/mristin/opinionated-commit-message
[2] https://chris.beams.io/posts/git-commit/