### PR TITLE
Enable Hoverfly to be installed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# How to contribute
+
+Firstly thanks for thinking of contributing - the project is [open source](https://opensource.guide/how-to-contribute/) and all contributions are very welcome :slightly_smiling_face: :boom: :thumbsup:
+
+## How to report a bug or suggest a new feature
+
+[Create an issue](https://github.com/agilepathway/hoverfly-github-action/issues), describing the bug or new feature in as much detail as you can.
+
+## How to make a contribution
+
+  * [Create an issue](https://github.com/agilepathway/hoverfly-github-action/issues) describing the change you are proposing.
+  * [Create a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).  The project uses the _[fork and pull model](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-collaborative-development-models)_:
+    * [Fork the project](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks)
+    * Make your changes on your fork
+    * Write a [good commit message(s)](https://chris.beams.io/posts/git-commit/) for your changes
+    * [Create the pull request for your changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,109 @@
-# Container Action Template
+# Hoverfly GitHub Action
 
-To get started, click the `Use this template` button on this repository [which will create a new repository based on this template](https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/).
+[![reviewdog](https://github.com/agilepathway/hoverfly-github-action/workflows/reviewdog/badge.svg?branch=main&event=push)](https://github.com/agilepathway/hoverfly-github-action/actions?query=workflow%3Areviewdog+event%3Apush+branch%3Amain)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?maxAge=43200)](LICENSE)
 
-For info on how to build your first Container action, see the [toolkit docs folder](https://github.com/actions/toolkit/blob/master/docs/container-action.md).
+**[GitHub Action](https://github.com/features/actions) that installs [Hoverfly](https://docs.hoverfly.io/), so that it can be used in subsequent steps in your GitHub Actions CI/CD pipeline (e.g. when running tests that use Hoverfly).**
+
+
+## Using the Hoverfly action
+
+Using this action is as simple as:
+
+1. **create a `.github\workflows` directory** in your repository
+2. **create a 
+   [YAML](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows) 
+   file** in the `.github\workflows` directory (file name can be anything you like, 
+   with either a `.yml` or `.yaml` file extension), with this content:
+ 
+```
+---
+name: Hoverfly
+on:
+  push:
+
+jobs:
+
+  install-hoverfly:
+  name: Install
+  runs-on: ubuntu-latest
+  steps:
+    - name: Install Hoverfly
+      uses: agilepathway/hoverfly-github-action@main
+      with:
+        runner_github_workspace_path: ${{ github.workspace }}
+```
+
+You will also typically have additional steps both before and after the Hoverfly installation step,
+e.g. to checkout your code and to run your tests. Here's an example:
+
+```
+---
+name: Run tests
+on:
+  push:
+
+jobs:
+
+  run-tests:
+  name: Install Hoverfly and run tests
+  runs-on: ubuntu-latest
+  steps:
+    - name: Checkout code
+        uses: actions/checkout@v2
+    - name: Install Hoverfly
+      uses: agilepathway/hoverfly-github-action@main
+      with:
+        runner_github_workspace_path: ${{ github.workspace }}
+    - name: Run Tests
+        run: <command-to-run-your-tests>
+```
+
+Once the Hoverfly installation has completed, both the 
+[Hoverfly](https://docs.hoverfly.io/en/latest/pages/reference/hoverfly/hoverflycommands.html) and 
+[Hoverctl](https://docs.hoverfly.io/en/latest/pages/keyconcepts/hoverctl.html) 
+commands are available to you for the remainder of your GitHub Actions workflow:
+- `hoverfly`
+- `hoverctl`
+
+
+## Specifying the Hoverfly version
+
+Example:
+
+```
+  steps:
+    - name: Install Hoverfly
+      uses: agilepathway/hoverfly-github-action@main
+      with:
+        version: v1.3.0
+        runner_github_workspace_path: ${{ github.workspace }}
+```
+
+`version` can be any [released Hoverfly version](https://github.com/SpectoLabs/hoverfly/releases).
+If you do not provide a version, it will default to the 
+[latest](https://github.com/SpectoLabs/hoverfly/releases/latest) release.
+
+
+## Runner GitHub Workspace path and Hoverfly installation location
+
+As per the above examples, you have to provide the following parameter:
+
+`runner_github_workspace_path: ${{ github.workspace }}`
+
+The value must always be `${{ github.workspace }}`
+
+This is so that the Hoverfly binaries are added to the path properly.
+
+The Hoverfly binaries are installed at `${{ github.workspace }}/bin`
+
+(The [GitHub workspace directory is persistent throughout the GitHub Action workflow](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#filesystems-on-github-hosted-runners), which means that the binaries are available to any subsequent workflow steps.)
+
+
+## Suggestions / bug reports / contributions
+
+The project is [open source](https://opensource.guide/how-to-contribute/) and all contributions are very welcome :slightly_smiling_face: :boom: :thumbsup:
+
+* [How to report a bug or suggest a new feature](CONTRIBUTING.md#how-to-report-a-bug-or-suggest-a-new-feature)
+
+* [How to make a contribution](CONTRIBUTING.md#how-to-make-a-contribution)

--- a/action.yml
+++ b/action.yml
@@ -5,14 +5,24 @@ description: >
   so that other GitHub Actions can use it easily (e.g. for testing)
 author: 'John Boyes'
 inputs:
-  myInput:
-    description: 'Input to use'
-    default: 'world'
+  version:
+    description: >
+      The Hoverfly version to install.
+      Can be any released Hoverfly version:
+      https://github.com/SpectoLabs/hoverfly/releases
+      Defaults to the latest version.
+    default: 'v1.3.0'
+    required: false
+  runner_github_workspace_path:
+    description: >
+      Always set this to be: `<dollarsign>{{ github.workspace}}`,
+      replacing <dollarsign> with $
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.myInput }}
+    - ${{ inputs.runner_github_workspace_path }}
 branding:
   icon: 'play'
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,28 @@
-#!/bin/sh -l
+#!/bin/sh
 
-echo "hello $1"
+export RUNNER_GITHUB_WORKSPACE_PATH=$1
+export RUNNER_HOVERFLY_INSTALL_PATH=$RUNNER_GITHUB_WORKSPACE_PATH/bin
+export CONTAINER_HOVERFLY_INSTALL_PATH=$GITHUB_WORKSPACE/bin
+export HOVERFLY_PLATFORM=linux_amd64
+export HOVERFLY_VERSION=$INPUT_VERSION
+export HOVERFLY_BUNDLE=hoverfly_bundle_$HOVERFLY_PLATFORM
+export HOVERFLY_DOWNLOAD_URL=https://github.com/SpectoLabs/hoverfly/releases/download/
+
+mkdir -p "$CONTAINER_HOVERFLY_INSTALL_PATH"
+mkdir -p /tmp/hoverfly
+cd /tmp/hoverfly || exit
+
+wget "$HOVERFLY_DOWNLOAD_URL$HOVERFLY_VERSION/$HOVERFLY_BUNDLE.zip"
+unzip $HOVERFLY_BUNDLE.zip
+install -m 755 hoverfly "$CONTAINER_HOVERFLY_INSTALL_PATH"
+install -m 755 hoverctl "$CONTAINER_HOVERFLY_INSTALL_PATH"
+
+cd /tmp || exit
+rm -rf /tmp/hoverfly
+
+echo "Installed hoverfly and hoverctl"
+
+"$CONTAINER_HOVERFLY_INSTALL_PATH/hoverfly" -version
+"$CONTAINER_HOVERFLY_INSTALL_PATH/hoverctl" version
+
+echo "::add-path::$RUNNER_HOVERFLY_INSTALL_PATH"


### PR DESCRIPTION
Prior to this commit the Action still contained the "Hello world" 
content from the template Container Action[1] that this repo was 
generated from.

Also added a `CONTRIBUTING.md`.

Out of scope for this PR: end to end tests (#21) 

[1] https://github.com/actions/container-action

