### PR TITLE
Ensure dependabot notifies of new versions

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -1,0 +1,14 @@
+---
+name: Dependabot hack
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - never-trigger-this-dependabot-hack-workflow
+
+jobs:
+
+  dependabot_hack:
+    name: Ensure dependabot version checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: agilepathway/label-checker:v1.0.8


### PR DESCRIPTION
Dependabot does not currently update [references to Docker
Containers][1] in GitHub Actions.  So this is a hack to ensure that
Dependabot still notifies us (via Pull Requests) whenever the [Label
Checker][2] is updated.

We never want this fake GitHub Action to be triggered (because the
Dependabot doesn't need the action to be triggered in order to carry out
it's version updating), so we have set it to only ever trigger on a
branch name which we will never have.

The PR that Dependabot creates will only have the update for this file,
so we'll have to then manually update the version in the
`check_semver_labels.yml` too.

[1]: https://dependabot.com/github-actions/
[2]: https://github.com/agilepathway/label-checker