### PR TITLE
Create automatic PR on new ShellCheck version

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -12,3 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: agilepathway/label-checker:v1.0.8
+      - uses: koalaman/shellcheck:v0.7.0


### PR DESCRIPTION
We will still have to manually update the ShellCheck version in the
devcontainer Dockerfile, but the automatic PR will at least alert us
when there is a new version to upgrade to.

We are using a Dependabot hack for this alert, by creating a "fake"
GitHub Action just for the purposes of alerting us to updated versions.

Even though ShellCheck is not an actual action itself, it doesn't matter
to us as the fake action will never run and is instead only used for
Dependabot to trigger version update alerts via PRs.