### PR TITLE
Fix incorrectly specified dependabot dependencies

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -11,5 +11,5 @@ jobs:
     name: Ensure dependabot version checks
     runs-on: ubuntu-latest
     steps:
-      - uses: agilepathway/label-checker:v1.0.8
-      - uses: koalaman/shellcheck:v0.7.0
+      - uses: agilepathway/label-checker@v1.0.8
+      - uses: koalaman/shellcheck@v0.7.0


### PR DESCRIPTION
There was a typo, causing the dependencies not to be picked up by
the Dependabot version update checks.