### PR TITLE
Use Dependabot for Hoverfly version notifications

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: agilepathway/label-checker@v1.0.8
       - uses: koalaman/shellcheck@v0.7.0
       - uses: golang/go@go1.14.6
+      - uses: SpectoLabs/hoverfly@v1.2.0


### PR DESCRIPTION
Dependabot will create a PR whenever there is a new version of Hoverfly
released. We will then amend the PR by manually updating to the new
version in the various places in the code where it is used. We could in
theory automate this by, for instance, having a GitHub Action that does
it, triggered by the Dependabot PR, but let's start simple - it could
well be overkill to do this.  Especially as Dependabot itself may
provide a solution to this one day.