### PR TITLE
Exclude Dependabot commits from message checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -7,7 +7,11 @@ on:  # yamllint disable-line rule:truthy
       - edited
       - reopened
       - synchronize
+    branches-ignore:
+      - '*dependabot/github_actions/*'
   push:
+    branches-ignore:
+      - '*dependabot/github_actions/*'
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
Commits which are automatically generated by Dependabot typically have
a body line length of [more than the 72 character limit][1] which our
check requires.

[1] https://github.com/dependabot/feedback/issues/165#issuecomment-544498501