### PR TITLE
Fix exclusion of Dependabot commit message checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -8,10 +8,10 @@ on:  # yamllint disable-line rule:truthy
       - reopened
       - synchronize
     branches-ignore:
-      - '*dependabot/github_actions/*'
+      - '*dependabot/github_actions/**'
   push:
     branches-ignore:
-      - '*dependabot/github_actions/*'
+      - '*dependabot/github_actions/**'
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
To ignore the Dependabot branches we need to use `**` at the end of our
filter, as [the single `*` we had before does not match the `/`
character][1]

[1]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet