### PR TITLE
Fix exclusion of Dependabot commit message checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -7,14 +7,11 @@ on:  # yamllint disable-line rule:truthy
       - edited
       - reopened
       - synchronize
-    branches-ignore:
-      - '*dependabot/github_actions/**'
   push:
-    branches-ignore:
-      - '*dependabot/github_actions/**'
 
 jobs:
   check-commit-message-style:
+    if: github.actor!= 'dependabot[bot]'
     name: Check commit message style
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To ignore Dependabot commits from our commit message checks we need
to filter out the GitHub actor, rather than ignoring branches. ignoring
branches does not work in the way we want it to for pull requests, as
[it only looks at the base branch][1]

[1]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags