### PR TITLE
Fix exclusion of Dependabot commit message checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check-commit-message-style:
-    if: github.actor!= 'dependabot[bot]'
+    if: github.actor!= 'dependabot[bot]' && contains(github.head_ref, 'dependabot/github_actions/') == false
     name: Check commit message style
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We need to filter out the Dependabot branches as well as our existing
filtering out of commits by Dependabot.  This is because if we need to
update versions manually, we add our own commits to the PRs that
Dependabot creates.