### PR TITLE
Stop checking commit messsages on main branch

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -8,6 +8,8 @@ on:  # yamllint disable-line rule:truthy
       - reopened
       - synchronize
   push:
+    branches-ignore:
+      - main
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
No need to check them as we cannot commit directly to the main branch,
which means that all commits are already checked before they are merged
to main.