### PR TITLE
Add patch label to all Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "patch"


### PR DESCRIPTION
The Dependabot PRs will continue to be labelled with `dependencies` too.

[Setting custom labels][1]

[1]: https://docs.github.com/en/github/administering-a-repository/customizing-dependency-updates#setting-custom-labels