### PR TITLE
Set reviewer for all Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     labels:
       - "dependencies"
       - "patch"
+    reviewers:
+      - "johnboyes"


### PR DESCRIPTION
This is to ensure that the core maintainer gets notified when Dependabot
creates a PR.

See:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#reviewers