### PR TITLE
Allow long URLs in commit messages

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2.1.0
+        uses: mristin/opinionated-commit-message@v2.1.2
         with:
           allow-one-liners: 'true'


### PR DESCRIPTION
Updated to the latest version of the commit message checker which
contains [this new feature][1]

Closes #15

[1]: https://github.com/mristin/opinionated-commit-message/issues/59