### PR TITLE
Run the tests nightly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 ---
 name: Test
-on: push  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  # Run the tests on every push, and also at 3am every night
+  push:
+  schedule:
+    - cron: '0 3 * * *'  # * is a special character in YAML so you have to quote this string
 env:
   ASSERT_VERSION: "| grep -q $HOVERFLY_VERSION"
   ASSERT_HOVERFLY_NOT_INSTALLED: "! hoverfly -version"


### PR DESCRIPTION
This is to ensure that we continue to have confidence that the
functionality works, and so that we are alerted to any regressions.

Using the [GitHub Actions scheduler functionality][1]

[1]: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events