### PR TITLE
Create Dockerfile dependencies issue every 6 month

### DIFF
--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -47,7 +47,7 @@ For major version updates, we should test that the remote container works succes
 
 ## Dockerfile dependencies
 
-We have [pinned the linux dependencies in the devcontainer Dockerfile](https://github.com/agilepathway/hoverfly-github-action/pull/46/files), but there is no mechanism to automatically update them, currently.  It looks like [it's on Dependabot's roadmap](https://github.com/dependabot/dependabot-core/issues/2129#issuecomment-511552345), so we have reminders every 6 months to 
+We have [pinned the linux dependencies in the devcontainer Dockerfile](https://github.com/agilepathway/hoverfly-github-action/pull/46/files), but there is no mechanism to automatically update them, currently.  It looks like [it's on Dependabot's roadmap](https://github.com/dependabot/dependabot-core/issues/2129#issuecomment-511552345), so we have [an issue automatically created every 6 months](https://github.com/agilepathway/hoverfly-github-action/pull/59) to 
 1. update the dependencies manually
 2. see if Dependabot now offer this functionality
 

--- a/.github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md
+++ b/.github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md
@@ -1,0 +1,18 @@
+---
+name: Update dependencies in devcontainer Dockerfile
+about: Stay up to date with Dockerfile dependencies
+title: Update dependencies in devcontainer Dockerfile
+labels: ''
+assignees: ''
+
+---
+
+
+We have [pinned the linux dependencies in the devcontainer Dockerfile](https://github.com/agilepathway/hoverfly-github-action/pull/46/files), but there is no mechanism to automatically update them, currently. It looks like [it's on Dependabot's roadmap](https://github.com/dependabot/dependabot-core/issues/2129#issuecomment-511552345), so this GitHub Issue gets automatically created every 6 months to:
+
+- [ ] update the dependencies manually:
+    1. Temporarily unpin the versions (i.e. remove `=<version>` from each package in the Dockerfile)
+    2. Execute the Dockerfile (e.g. if it's a remote container Dockerfile build the remote container)
+    3. Run `apt-cache policy <package>` for each package, to see the version installed
+    4. Pin all the versions, replacing any old versions with new ones
+- [ ] see if Dependabot now offer this functionality (in which case we can do it automatically, from then on)

--- a/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
+++ b/.github/workflows/schedule_dockerfile_dependency_updates_issue.yml
@@ -1,0 +1,28 @@
+---
+name: Create issue every 6 months to update Dockerfile dependencies
+on:  # yamllint disable-line rule:truthy
+  # Scheduled for 4am on 10th March and 10th Sept every year
+  schedule:
+    - cron: '0 4 10 3,9 *'  # * is a special character in YAML so we have to quote this string
+
+jobs:
+  create_issue:
+    name: Create issue to update Dockerfile dependencies
+    runs-on: ubuntu-20.04
+    steps:
+
+      # Repo code checkout required if `template` is used
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: issue-bot
+        uses: imjohnbo/issue-bot@v2
+        with:
+          assignees: "johnboyes"
+          labels: "dependencies"
+          pinned: false
+          close-previous: false
+          # assignees & labels in the template are overridden by the values specified in this action
+          template: ".github/ISSUE_TEMPLATE/scheduled/update-dockerfile-dependencies.md"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have to update the Dockerfile dependencies manually at the moment,
so we now have an issue automatically created every 6 months to prompt
us to do so.